### PR TITLE
Support correct Resque.enqueue interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ If you attempt to queue a unique job multiple times, it is ignored:
 
 ```
 Resque.enqueue UpdateCat, 1
-=> "OK"
+=> true
 Resque.enqueue UpdateCat, 1
-=> "EXISTED"
+=> nil
 Resque.enqueue UpdateCat, 1
-=> "EXISTED"
+=> nil
 Resque.size :cats
 => 1
 Resque.enqueued? UpdateCat, 1

--- a/lib/resque_ext/resque.rb
+++ b/lib/resque_ext/resque.rb
@@ -1,5 +1,22 @@
 module Resque
   class << self
+    def enqueue_to(queue, klass, *args)
+      # Perform before_enqueue hooks. Don't perform enqueue if any hook returns false
+      before_hooks = Plugin.before_enqueue_hooks(klass).collect do |hook|
+        klass.send(hook, *args)
+      end
+      return nil if before_hooks.any? { |result| result == false }
+
+      result = Job.create(queue, klass, *args)
+      return nil if result == "EXISTED"
+
+      Plugin.after_enqueue_hooks(klass).each do |hook|
+        klass.send(hook, *args)
+      end
+
+      true
+    end
+
     def enqueued?(klass, *args)
       enqueued_in?(queue_from_class(klass), klass, *args)
     end

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -22,4 +22,24 @@ class ResqueTest < MiniTest::Spec
   it "does not raise when deleting an empty queue" do
     Resque.remove_queue(:unique)
   end
+
+  describe "#enqueue_to" do
+    describe "non-unique job" do
+      it "should return true if job was enqueued" do
+        assert Resque.enqueue_to(:normal, FakeJob)
+        assert Resque.enqueue_to(:normal, FakeJob)
+      end
+    end
+
+    describe "unique job" do
+      it "should return true if job was enqueued" do
+        assert Resque.enqueue_to(:normal, FakeUniqueJob)
+      end
+
+      it "should return nil if job already existed" do
+        Resque.enqueue_to(:normal, FakeUniqueJob)
+        assert_nil Resque.enqueue_to(:normal, FakeUniqueJob)
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Resque.enqueue` method returns either `nil`, or `true` https://github.com/resque/resque/blob/master/lib/resque.rb#L361-L362 (https://github.com/resque/resque/commit/1f7411d27f0f828107d98be0345799e4eeb7f878)
`"EXISTED"` is the result of `Resque::Job.create` method in current implementation, but `Resque.enqueue` returns `true` anyway. This makes impossible to understand the job was enqueued or not.
`Resque.enqueue` will return nil for already added jobs after this patch.
