### PR TITLE
Use after hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ gem 'resque_solo'
 class UpdateCat
   include Resque::Plugins::UniqueJob
   @queue = :cats
+  @lock_after_execution_period = 20
 
   def self.perform(cat_id)
     # do something

--- a/lib/resque_ext/job.rb
+++ b/lib/resque_ext/job.rb
@@ -1,39 +1,12 @@
 module Resque
   class Job
     class << self
-      # Mark an item as queued
-      def create_solo(queue, klass, *args)
-        item = { class: klass.to_s, args: args }
-        if Resque.inline? || !ResqueSolo::Queue.is_unique?(item)
-          return create_without_solo(queue, klass, *args)
-        end
-        return "EXISTED" if ResqueSolo::Queue.queued?(queue, item)
-        create_return_value = false
-        # redis transaction block
-        Resque.redis.multi do
-          create_return_value = create_without_solo(queue, klass, *args)
-          ResqueSolo::Queue.mark_queued(queue, item)
-        end
-        create_return_value
-      end
-
-      # Mark an item as unqueued
-      def reserve_solo(queue)
-        item = reserve_without_solo(queue)
-        ResqueSolo::Queue.mark_unqueued(queue, item) if item && !Resque.inline?
-        item
-      end
-
       # Mark destroyed jobs as unqueued
       def destroy_solo(queue, klass, *args)
         ResqueSolo::Queue.destroy(queue, klass, *args) unless Resque.inline?
         destroy_without_solo(queue, klass, *args)
       end
 
-      alias_method :create_without_solo, :create
-      alias_method :create, :create_solo
-      alias_method :reserve_without_solo, :reserve
-      alias_method :reserve, :reserve_solo
       alias_method :destroy_without_solo, :destroy
       alias_method :destroy, :destroy_solo
     end

--- a/lib/resque_ext/resque.rb
+++ b/lib/resque_ext/resque.rb
@@ -1,22 +1,5 @@
 module Resque
   class << self
-    def enqueue_to(queue, klass, *args)
-      # Perform before_enqueue hooks. Don't perform enqueue if any hook returns false
-      before_hooks = Plugin.before_enqueue_hooks(klass).collect do |hook|
-        klass.send(hook, *args)
-      end
-      return nil if before_hooks.any? { |result| result == false }
-
-      result = Job.create(queue, klass, *args)
-      return nil if result == "EXISTED"
-
-      Plugin.after_enqueue_hooks(klass).each do |hook|
-        klass.send(hook, *args)
-      end
-
-      true
-    end
-
     def enqueued?(klass, *args)
       enqueued_in?(queue_from_class(klass), klass, *args)
     end

--- a/lib/resque_solo/queue.rb
+++ b/lib/resque_solo/queue.rb
@@ -7,11 +7,12 @@ module ResqueSolo
       end
 
       def mark_queued(queue, item)
-        return unless is_unique?(item)
         key = unique_key(queue, item)
-        redis.set(key, 1)
+        res = redis.setnx(key, 1)
+        return false unless res
         ttl = item_ttl(item)
         redis.expire(key, ttl) if ttl >= 0
+        res
       end
 
       def mark_unqueued(queue, job)

--- a/lib/resque_solo/unique_job.rb
+++ b/lib/resque_solo/unique_job.rb
@@ -45,6 +45,14 @@ module Resque
         def lock_after_execution_period
           @lock_after_execution_period ||= 0
         end
+
+        # We want this to run first in before_enqueue_hooks (which are alpha sorted), so name appropriately
+        def before_enqueue_001_solo_job(*args)
+          queue_name = self.instance_variable_get(:@queue)
+          item = { class: self.to_s, args: args }
+          !ResqueSolo::Queue.queued?(queue_name, item)
+        end
+
       end
     end
   end

--- a/resque_solo.gemspec
+++ b/resque_solo.gemspec
@@ -20,5 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "fakeredis", "~> 0.4"
   spec.add_development_dependency "minitest", "~> 5.8"
+  spec.add_development_dependency "minitest-reporters", "~> 1.1"
   spec.add_development_dependency "rake", "~> 11.2"
+  spec.add_development_dependency "m", "~> 1.5"
 end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -15,7 +15,7 @@ class JobTest < MiniTest::Spec
     Resque.enqueue FakeUniqueJob, "foo"
     Resque.enqueue FakeUniqueJob, "foo"
     assert_equal 1, Resque.size(:unique)
-    Resque.reserve(:unique)
+    perform_one_manually(:unique)
     assert_equal 0, Resque.size(:unique)
     Resque.enqueue FakeUniqueJob, "foo"
     Resque.enqueue FakeUniqueJob, "foo"
@@ -48,8 +48,7 @@ class JobTest < MiniTest::Spec
   it "mark jobs as unqueued when they raise an exception" do
     2.times { Resque.enqueue(FailingUniqueJob, "foo") }
     assert_equal 1, Resque.size(:unique)
-    worker = Resque::Worker.new(:unique)
-    worker.work 0
+    assert_raises { perform_one_manually(:unique) }
     assert_equal 0, Resque.size(:unique)
     2.times { Resque.enqueue(FailingUniqueJob, "foo") }
     assert_equal 1, Resque.size(:unique)
@@ -98,7 +97,7 @@ class JobTest < MiniTest::Spec
 
   it "honor lock_after_execution_period in the redis key" do
     Resque.enqueue UniqueJobWithLock
-    Resque.reserve(:unique_with_lock)
+    perform_one_manually(:unique_with_lock)
     keys = Resque.redis.keys "solo:queue:unique_with_lock:job:*"
     assert_equal 1, keys.length
     assert_in_delta UniqueJobWithLock.lock_after_execution_period,

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -12,7 +12,8 @@ class ResqueTest < MiniTest::Spec
   it "enqueues normal jobs" do
     Resque.enqueue FakeJob, "x"
     Resque.enqueue FakeJob, "x"
-    assert_equal 2, Resque.size(:normal)
+    queue_name = FakeJob.instance_variable_get(:@queue)
+    assert_equal 2, Resque.size(queue_name)
   end
 
   it "is not able to report if a non-unique job was enqueued" do
@@ -26,19 +27,25 @@ class ResqueTest < MiniTest::Spec
   describe "#enqueue_to" do
     describe "non-unique job" do
       it "should return true if job was enqueued" do
-        assert Resque.enqueue_to(:normal, FakeJob)
-        assert Resque.enqueue_to(:normal, FakeJob)
+        queue_name = FakeJob.instance_variable_get(:@queue)
+        assert Resque.enqueue_to(queue_name, FakeJob)
+        assert Resque.enqueue_to(queue_name, FakeJob)
       end
     end
 
     describe "unique job" do
+      before do
+        @queue_name = FakeUniqueJob.instance_variable_get(:@queue)
+      end
+
       it "should return true if job was enqueued" do
-        assert Resque.enqueue_to(:normal, FakeUniqueJob)
+        assert Resque.enqueue_to(@queue_name, FakeUniqueJob)
       end
 
       it "should return nil if job already existed" do
-        Resque.enqueue_to(:normal, FakeUniqueJob)
-        assert_nil Resque.enqueue_to(:normal, FakeUniqueJob)
+        Resque.enqueue_to(@queue_name, FakeUniqueJob)
+        assert Resque.enqueued?(FakeUniqueJob)
+        assert_nil Resque.enqueue_to(@queue_name, FakeUniqueJob)
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,11 +4,14 @@ if ENV["SIMPLE_COV"]
 end
 
 require "minitest/autorun"
+require "minitest/reporters"
 require "resque_solo"
 require "fake_jobs"
-require "fakeredis"
+require "fakeredis/minitest"
 begin
   require "pry-byebug"
 rescue LoadError
   # ignore
 end
+
+Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new({ color: true })]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,3 +15,7 @@ rescue LoadError
 end
 
 Minitest::Reporters.use! [Minitest::Reporters::DefaultReporter.new({ color: true })]
+
+def perform_one_manually(queue_name)
+  Resque::Job.reserve(queue_name).perform
+end


### PR DESCRIPTION
Gets rid of most of the monkeypatching in favor of before and around hooks, as per https://github.com/neighborland/resque_solo/issues/7

Note that resque hooks don't give the queue that the job was pulled from, so there's no way to ensure a unique job across multiple queues, but it didn't look like that was in scope as far as I could see from the existing tests.
