### PR TITLE
Fix test warnings

### DIFF
--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class JobTest < MiniTest::Spec
   before do
-    Resque.redis.flushall
+    Resque.redis.redis.flushdb
   end
 
   it "enqueue identical jobs once" do

--- a/test/resque_test.rb
+++ b/test/resque_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ResqueTest < MiniTest::Spec
   before do
-    Resque.redis.flushall
+    Resque.redis.redis.flushdb
   end
 
   it "is a valid plugin" do


### PR DESCRIPTION
* Call flushdb directly on redis

Warning:
Passing 'flushall' command to redis as is; administrative commands
cannot be effectively namespaced and should be called on the redis
connection directly; passthrough has been deprecated and will be
removed in redis-namespace 2.0