### PR TITLE
Hack to support resque-priority_enqueue: 

### DIFF
--- a/lib/resque_ext/job.rb
+++ b/lib/resque_ext/job.rb
@@ -36,6 +36,25 @@ module Resque
       alias_method :reserve, :reserve_solo
       alias_method :destroy_without_solo, :destroy
       alias_method :destroy, :destroy_solo
+
+      # Hack to support resque-priority_enqueue: https://github.com/coupa/resque-priority_enqueue
+      def priority_create_solo(queue, klass, *args)
+        item = { class: klass.to_s, args: args }
+        if Resque.inline? || !ResqueSolo::Queue.is_unique?(item)
+          return priority_create_without_solo(queue, klass, *args)
+        end
+        return "EXISTED" if ResqueSolo::Queue.queued?(queue, item)
+        priority_create_return_value = false
+        # redis transaction block
+        Resque.redis.multi do
+          priority_create_return_value = priority_create_without_solo(queue, klass, *args)
+          ResqueSolo::Queue.mark_queued(queue, item)
+        end
+        priority_create_return_value
+      end
+
+      alias_method :priority_create_without_solo, :priority_create
+      alias_method :priority_create, :priority_create_solo
     end
   end
 end


### PR DESCRIPTION
This is a hack I needed to implement in order to make this library compatible with the [resque-priority_enqueue](https://github.com/coupa/resque-priority_enqueue) plugin.

I don't know if there is a better way to accomplish this.