### PR TITLE
Fix deprecation warning when comparison with Redis::Future

### DIFF
--- a/lib/resque_ext/resque.rb
+++ b/lib/resque_ext/resque.rb
@@ -11,7 +11,9 @@ module Resque
       end
       return nil if before_hooks.any? { |result| result == false }
 
-      result = Job.create(queue, klass, *args)
+      job = Job.create(queue, klass, *args)
+      result = job.class.eql?(Redis::Future) ? job.value : job
+
       return nil if result == "EXISTED"
 
       Plugin.after_enqueue_hooks(klass).each do |hook|


### PR DESCRIPTION
Faced with deprecation warning message:
The methods == and != are deprecated for Redis::Future and will be removed in 5.0.0 - You probably meant to call .value == or .value != (/usr/.rvm/gems/ruby-3.0.6/gems/resque_solo-0.5.0/lib/resque_ext/resque.rb:15:in `enqueue_to')